### PR TITLE
Brewfile blacklist

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -342,23 +342,17 @@ DAPTIV_BREWFILE="$HOME/.Daptiv.Brewfile"
 DAPTIV_BREWFILE_BLACKLIST="$DAPTIV_BREWFILE.blacklist"
 if [ -f "$DAPTIV_BREWFILE" ]; then
   log "Installing from Daptiv Brewfile:"
-  if [ -f "$DAPTIV_BREWFILE_BLACKLIST"]; then
-    log "Blacklisting Daptiv Brewfile"
-    rm -f $DAPTIV_BREWFILE_BLACKLIST
+  if [ ! -f "$DAPTIV_BREWFILE_BLACKLIST" ]; then
+    brew bundle check --file="$DAPTIV_BREWFILE" || brew bundle --file="$DAPTIV_BREWFILE"
+  else
+    log "Using blacklist"
     while read BLACKLIST_LINE
     do
       if [ ! -z $BLACKLIST_REGEX ]; then BLACKLIST_REGEX+="|"; fi
       BLACKLIST_REGEX+="\"$BLACKLIST_LINE\""
     done < $DAPTIV_BREWFILE_BLACKLIST
-    sed -E -i '.blbak' "/$BLACKLIST_REGEX/d" $DAPTIV_BREWFILE
+    sed -E "/$BLACKLIST_REGEX/d" $DAPTIV_BREWFILE | brew bundle check --file=- || sed -E "/$BLACKLIST_REGEX/d" $DAPTIV_BREWFILE | brew bundle --file=-
   fi
-
-  brew bundle check --file="$DAPTIV_BREWFILE" || brew bundle --file="$DAPTIV_BREWFILE"
-
-  if [ -e $DAPTIV_BREWFILE_BLACKLIST ]; then
-    mv $DAPTIV_BREWFILE_BLACKLIST $DAPTIV_BREWFILE
-  fi
-
   logk
 fi
 

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -332,9 +332,26 @@ fi
 
 # Install from Daptiv Brewfile
 DAPTIV_BREWFILE="$HOME/.Daptiv.Brewfile"
+DAPTIV_BREWFILE_BLACKLIST="$DAPTIV_BREWFILE.blacklist"
 if [ -f "$DAPTIV_BREWFILE" ]; then
   log "Installing from Daptiv Brewfile:"
+  if [ -f "$DAPTIV_BREWFILE_BLACKLIST"]; then
+    log "Blacklisting Daptiv Brewfile"
+    rm -f $DAPTIV_BREWFILE_BLACKLIST
+    while read BLACKLIST_LINE
+    do
+      if [ ! -z $BLACKLIST_REGEX ]; then BLACKLIST_REGEX+="|"; fi
+      BLACKLIST_REGEX+="\"$BLACKLIST_LINE\""
+    done < $DAPTIV_BREWFILE_BLACKLIST
+    sed -E -i '.blbak' "/$BLACKLIST_REGEX/d" $DAPTIV_BREWFILE
+  fi
+
   brew bundle check --file="$DAPTIV_BREWFILE" || brew bundle --file="$DAPTIV_BREWFILE"
+
+  if [ -e $DAPTIV_BREWFILE_BLACKLIST ]; then
+    mv $DAPTIV_BREWFILE_BLACKLIST $DAPTIV_BREWFILE
+  fi
+
   logk
 fi
 

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -352,13 +352,18 @@ if [ -f "$DAPTIV_BREWFILE" ]; then
   if [ ! -f "$DAPTIV_BREWFILE_BLACKLIST" ]; then
     brew bundle check --file="$DAPTIV_BREWFILE" || brew bundle --file="$DAPTIV_BREWFILE"
   else
-    log "Using blacklist"
+    log "Generating brewfile blacklist"
     while read BLACKLIST_LINE
     do
       if [ ! -z $BLACKLIST_REGEX ]; then BLACKLIST_REGEX+="|"; fi
       BLACKLIST_REGEX+="\"$BLACKLIST_LINE\""
     done < $DAPTIV_BREWFILE_BLACKLIST
-    sed -E "/$BLACKLIST_REGEX/d" $DAPTIV_BREWFILE | brew bundle check --file=- || sed -E "/$BLACKLIST_REGEX/d" $DAPTIV_BREWFILE | brew bundle --file=-
+
+    BREWFILE_CLEAN='/tmp/daptiv.brewfile.clean'
+    log "Using clean brewfile: $BREWFILE_CLEAN"
+    sed -E "/$BLACKLIST_REGEX/d" $DAPTIV_BREWFILE > $BREWFILE_CLEAN
+
+    brew bundle check --file="$BREWFILE_CLEAN" || brew bundle --file="$BREWFILE_CLEAN"
   fi
   logk
 fi

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -284,6 +284,13 @@ else
   logk
 fi
 
+# Halt if requested before Daptiv-specific setup
+if [ -n "$EXIT_BEFORE_DAPTIV" ]; then
+  log "You requested exit before Daptiv-specific setup. Strap process not completed."
+  STRAP_SUCCESS=1
+  exit
+fi
+
 # Setup Daptiv dotfiles
 DOTFILES_URL="https://github.com/daptiv/dotfiles"
 DOTFILES_DIR="$HOME/.daptiv-dotfiles"

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -305,13 +305,6 @@ else
   logk
 fi
 
-# Halt if requested before Daptiv-specific setup
-if [ -n "$EXIT_BEFORE_DAPTIV" ]; then
-  log "You requested exit before Daptiv-specific setup. Strap process not completed."
-  STRAP_SUCCESS=1
-  exit
-fi
-
 # Setup dotfiles
 USER_DOTFILES_EXISTS=
 if [ -n "$STRAP_GITHUB_USER" ]; then

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -437,15 +437,16 @@ fi
 
 # Run user dotfiles scripts
 if [ -n "$USER_DOTFILES_EXISTS" ]; then
-  pushd ~/.dotfiles > /dev/null
-  for i in script/setup script/bootstrap; do
-    if [ -f "$i" ] && [ -x "$i" ]; then
-      log "Running dotfiles $i:"
-      "$i" 2>/dev/null
-      break
-    fi
-  done
-  popd > /dev/null
+  (
+    cd ~/.dotfiles
+    for i in script/setup script/bootstrap; do
+      if [ -f "$i" ] && [ -x "$i" ]; then
+        log "Running dotfiles $i:"
+        "$i" 2>/dev/null
+        break
+      fi
+    done
+  )
   logk
 fi
 

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -323,6 +323,13 @@ if git ls-remote "$DOTFILES_URL" &>/dev/null; then
   logk
 fi
 
+# Uninstall non-Brew hostess
+if [ "$GOPATH/go/bin/hostess" -ef /usr/local/bin/hostess ]; then
+  log "Uninstalling non-Brew hostess"
+  rm -f /usr/local/bin/hostess
+  rm -f "$GOPATH/go/bin/hostess"
+fi
+
 # Check for broken cask installs
 DAPTIV_DOTFILES="$HOME/.daptiv-dotfiles"
 if [ -f "$DAPTIV_DOTFILES/script/fix-cask-installs.py" ]; then


### PR DESCRIPTION
✏️ 1/17/18

### Summary
- Move cloning of user dotfiles to start of Daptiv customization so user's files can be referenced in other logic.  The user's scripts are still run after Daptiv scripts.
- Add support for `.Daptiv.Brewfile.blacklist` so the user can choose not to have some default apps installed (e.g., I don't use Atom nor Sublime).  ~See note 1.~
- ~Add early exit option before Daptiv-specific setup (note 2).~ Removed
- Uninstall Hostess if it was not installed by Homebrew (note 3).

### Notes
1. ~Due to the Daptiv dotfiles' brewfile being run before user setup, this cannot be fully automated unless we reorganized the logic to:~ 
    1. ~Clone Daptiv and user dotfiles~
    2. ~Run user "presetup" script (where one could symlink a blacklist)~
    3. ~Run Daptiv `setup` (and brewfile), and `postbrew`~
    4. ~Run user `setup` (and brewfile), and `postbrew`~
2. ~The early exit is a workaround for not having note 1.  It provides an opportunity for the user to get Strap's base installation done so that useful tools are available to customize the rest of the process (i.e., git).  Presumably, this advanced user would then rerun strap to continue the customized, Daptiv-specific Strap process.~
3. I'm not sure why Hostess was installed manually.  I moved it to be installed via Homebrew (https://github.com/daptiv/dotfiles/pull/22) so this uninstall removes the manual installation from a previous run of strap.

### Review
- @jtrinklein 

/cc @stephenfowler @dachew 