### PR TITLE
Add daptiv/homebrew-tap tap for 'pinned' VirtualBox cask

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -276,7 +276,8 @@ else
 fi
 logk
 
-# Use "pinned" version of VirtualBox (5.2.22r126460)
+# Use "pinned" version of VirtualBox
+log "Pinning Homebrew casks to install VirtualBox 5.2.22r126460:"
 git --git-dir="$HOMEBREW_CASK/.git" --work-tree="$HOMEBREW_CASK" checkout eabf6ef195fcc22b08c4260b7d16b466bfdc2e7d -- Casks/virtualbox.rb
 git --git-dir="$HOMEBREW_CASK/.git" --work-tree="$HOMEBREW_CASK" checkout 1f57034b10a9e3e276a7682f6bf179cef1c14f31 -- Casks/virtualbox-extension-pack.rb
 

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -259,6 +259,13 @@ if ! type brew 1>/dev/null 2>&1 ; then
 fi
 logk
 
+# "Unpin" version of VirtualBox before brew update
+if [ -z "$HOMEBREW_REPOSITORY" ]; then
+  HOMEBREW_REPOSITORY=$(brew --repository)
+fi
+HOMEBREW_CASK="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-cask"
+git --git-dir="$HOMEBREW_CASK/.git" --work-tree="$HOMEBREW_CASK" reset --hard
+
 # Update Homebrew.
 export PATH="$HOMEBREW_PREFIX/bin:$PATH"
 logn "Updating Homebrew:"
@@ -268,6 +275,10 @@ else
   brew update 1>/dev/null 2>&1
 fi
 logk
+
+# Use "pinned" version of VirtualBox
+git --git-dir="$HOMEBREW_CASK/.git" --work-tree="$HOMEBREW_CASK" checkout eabf6ef195fcc22b08c4260b7d16b466bfdc2e7d -- Casks/virtualbox.rb
+git --git-dir="$HOMEBREW_CASK/.git" --work-tree="$HOMEBREW_CASK" checkout 1f57034b10a9e3e276a7682f6bf179cef1c14f31 -- Casks/virtualbox-extension-pack.rb
 
 # Install Homebrew Bundle, Cask and Services tap.
 log "Installing Homebrew taps and extensions:"

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -259,13 +259,6 @@ if ! type brew 1>/dev/null 2>&1 ; then
 fi
 logk
 
-# "Unpin" version of VirtualBox before brew update
-if [ -z "$HOMEBREW_REPOSITORY" ]; then
-  HOMEBREW_REPOSITORY=$(brew --repository)
-fi
-HOMEBREW_CASK="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-cask"
-git --git-dir="$HOMEBREW_CASK/.git" --work-tree="$HOMEBREW_CASK" reset --hard
-
 # Update Homebrew.
 export PATH="$HOMEBREW_PREFIX/bin:$PATH"
 logn "Updating Homebrew:"
@@ -276,17 +269,13 @@ else
 fi
 logk
 
-# Use "pinned" version of VirtualBox
-log "Pinning Homebrew casks to install VirtualBox 5.2.22r126460:"
-git --git-dir="$HOMEBREW_CASK/.git" --work-tree="$HOMEBREW_CASK" checkout eabf6ef195fcc22b08c4260b7d16b466bfdc2e7d -- Casks/virtualbox.rb
-git --git-dir="$HOMEBREW_CASK/.git" --work-tree="$HOMEBREW_CASK" checkout 1f57034b10a9e3e276a7682f6bf179cef1c14f31 -- Casks/virtualbox-extension-pack.rb
-
 # Install Homebrew Bundle, Cask and Services tap.
 log "Installing Homebrew taps and extensions:"
 brew bundle --file=- <<EOF
 tap 'caskroom/cask'
 tap 'homebrew/core'
 tap 'homebrew/services'
+tap 'daptiv/homebrew-tap'
 EOF
 logk
 

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -276,7 +276,7 @@ else
 fi
 logk
 
-# Use "pinned" version of VirtualBox
+# Use "pinned" version of VirtualBox (5.2.22r126460)
 git --git-dir="$HOMEBREW_CASK/.git" --work-tree="$HOMEBREW_CASK" checkout eabf6ef195fcc22b08c4260b7d16b466bfdc2e7d -- Casks/virtualbox.rb
 git --git-dir="$HOMEBREW_CASK/.git" --work-tree="$HOMEBREW_CASK" checkout 1f57034b10a9e3e276a7682f6bf179cef1c14f31 -- Casks/virtualbox-extension-pack.rb
 


### PR DESCRIPTION
## Summary
- Here's an alternative to writing our own VirtualBox install.  This maintains Homebrew as the installer; it just "pins" the two casks via git commit hash. What do you think ❓ 
- If you want to try it, pull down this branch and then run with the revert of dotfiles:
    ```
    DAPTIV_DOTFILES_BRANCH=revert-69-remove-virtualbox-for-now strap
    ```

## Review
- @linusruth 
- @dachew 
