### PR TITLE
prettier logs when running strap

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -288,12 +288,21 @@ logk
 
 # Install Homebrew Bundle, Cask and Services tap.
 logn "Installing Homebrew taps and extensions..."
+if [ -n "$STRAP_DEBUG" ]; then
+brew bundle --file=- <<EOF
+tap 'caskroom/cask'
+tap 'homebrew/core'
+tap 'homebrew/services'
+tap 'daptiv/homebrew-tap'
+EOF
+else
 brew bundle --file=- 1>/dev/null 2>&1 <<EOF
 tap 'caskroom/cask'
 tap 'homebrew/core'
 tap 'homebrew/services'
 tap 'daptiv/homebrew-tap'
 EOF
+fi
 logk
 
 # Check and install any remaining software updates.
@@ -339,9 +348,8 @@ if [ -n "$STRAP_GITHUB_USER" ]; then
   if [ -n "$USER_DOTFILES_EXISTS" ]; then
     logn "Fetching $DOTFILES_REPO from GitHub..."
     if [ ! -d "$HOME/.dotfiles" ]; then
-      logn "Cloning to ~/.dotfiles..."
+      logdebug "Cloning to ~/.dotfiles..."
       git clone $Q "$DOTFILES_URL" ~/.dotfiles
-      logk
     else
       (
         cd ~/.dotfiles


### PR DESCRIPTION
@jtrinklein
@greglboxer 

Reduce the log output and add some pretty bash coloring.  Let me know if this is too much but I figure there's always the debug option for really digging into things.  This, imo, is a prettier output format to look at.

```bash
hsnow@localhost:~/Downloads $ ./strap.sh 
Enter your password (for sudo access):
Password:
--> Configuring security settings... ✔
--> Checking full-disk encryption status... ✔
--> Install Xcode Command Line Tools... ✔
--> Configuring Git... ✔
--> Setting up GitHub HTTPS credentials... ✔
--> Setting up GitHub SSH key... ✔
--> Check for Homebrew... ✔
--> Updating Homebrew... ✔
--> Installing Homebrew taps and extensions... ✔
--> Checking for software updates... ✔
--> Ensure strap is cloned locally and up to date... ✔
--> Checking for remotes on git@github.com:heathsnow/dotfiles... ✔
--> Fetching heathsnow/dotfiles from GitHub... ✔
--> Updating local ~/.dotfiles repository... ✔
--> Fetching daptiv/dotfiles from GitHub... ✔
--> Check current branch of daptiv/dotfiles against requested branch... ✔
--> Running dotfiles script/setup... ✔
Box strap is complete.
Next steps:
1. run 'strap-daptiv' to run daptiv-dotfiles scripts/setup
2. run 'strap-user' to run user dotfiles scripts/setup
```